### PR TITLE
fix: Deprecation warning on keyword `body`

### DIFF
--- a/source/osc/message.d
+++ b/source/osc/message.d
@@ -91,7 +91,7 @@ struct Message {
         string toString()const
         in{
             assert(_args.length > 0);
-        }body{
+        }do{
             return _opCast!string();
         }
         

--- a/source/osc/oscstring.d
+++ b/source/osc/oscstring.d
@@ -53,7 +53,7 @@ struct OscString(char P){
             assert(str != "");
         }out{
             assert(_data.length%4 == 0);
-        }body{
+        }do{
             import std.conv;
             import std.algorithm;
             import std.array;
@@ -72,7 +72,7 @@ struct OscString(char P){
             import std.algorithm;
             // assert(!arr.canFind(null));
             assert(arr.length > 0);
-        }body{
+        }do{
             if(Prefix != '\0'){
                 import std.conv;
                 _data = Prefix.to!ubyte ~ _data;


### PR DESCRIPTION
Can be safely replaced with `do`: https://dlang.org/deprecate.html#body%20keyword